### PR TITLE
Fix duplicate attribute

### DIFF
--- a/example/etch-atom.js
+++ b/example/etch-atom.js
@@ -21,7 +21,7 @@ class Demo extends TabView {
   }
 
   render () {
-    return <div class='block'>
+    return <div className='block'>
       <Icon name='bell' size='medium'/>
       <Editor ref='editor' mini={true} on={{didStopChanging: this.editorChanged}}>
         foo bar!

--- a/lib/background-message.js
+++ b/lib/background-message.js
@@ -8,7 +8,7 @@ import { EtchComponent } from './etch-component'
 
 export class BackgroundMessage extends EtchComponent {
   render () {
-    return <ul class={`background-message ${this.props.notCentered ? '' : 'centered'}`}>
+    return <ul className={`background-message ${this.props.notCentered ? '' : 'centered'}`}>
       <li>
         {this.children}
       </li>

--- a/lib/icon.js
+++ b/lib/icon.js
@@ -31,6 +31,6 @@ export class Icon extends EtchComponent {
         style = 'font-size: 32px;'
         break
     }
-    return <span style={style} class={`icon icon-${this.props.name}`}></span>
+    return <span style={style} className={`icon icon-${this.props.name}`}></span>
   }
 }

--- a/lib/tree-view.js
+++ b/lib/tree-view.js
@@ -17,7 +17,7 @@ export class TreeView extends EtchComponent {
       cls += ' has-collapsable-children'
     }
 
-    return <ul class={cls}>
+    return <ul className={cls}>
       {this.children}
     </ul>
   }

--- a/lib/tree.js
+++ b/lib/tree.js
@@ -38,19 +38,19 @@ export class Tree extends EtchComponent {
       const events = this.props.on || {}
       events.click = this.onFold
 
-      return <li class={`list-nested-item ${this.props.collapsed ? 'collapsed' : 'expanded'}`}>
-        <div class='list-item' on={events}>
+      return <li className={`list-nested-item ${this.props.collapsed ? 'collapsed' : 'expanded'}`}>
+        <div className='list-item' on={events}>
           <span>
             {this.props.icon ? <Icon name={this.props.icon}/> : null}
             {this.props.text}
           </span>
         </div>
-        <ul class='list-tree'>
+        <ul className='list-tree'>
           {this.children}
         </ul>
       </li>
     } else {
-      return <li class='list-item' on={this.props.on}>
+      return <li className='list-item' on={this.props.on}>
         <span>
           {this.props.icon ? <Icon name={this.props.icon}/> : null}
           {this.props.text}


### PR DESCRIPTION
Use only `className` because simple `class` create double property.

![etch](https://user-images.githubusercontent.com/1855340/34125573-f677619a-e436-11e7-94c7-65aaf35eec89.JPG)
